### PR TITLE
Strict imports order

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -151,15 +151,12 @@
         <module name="UnusedImports">
             <property name="processJavadoc" value="true"/>
         </module>
-        <module name="ImportOrder">
-            <property name="groups" value="java,/^javax?\./,*"/>
-            <property name="ordered" value="true"/>
-            <property name="separated" value="true"/>
-            <property name="option" value="bottom"/>
-            <property name="separatedStaticGroups" value="true"/>
-            <property name="sortStaticImportsAlphabetically" value="true"/>
+        <module name="CustomImportOrder">
+            <property name="customImportOrderRules"
+                      value="STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SAME_PACKAGE(2)###STATIC"/>
+            <property name="separateLineBetweenGroups" value="true"/>
+            <property name="sortImportsInGroupAlphabetically" value="true"/>
         </module>
-
 
         <!-- Checks for Size Violations. -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -151,6 +151,7 @@
         <module name="UnusedImports">
             <property name="processJavadoc" value="true"/>
         </module>
+        <module name="AvoidStarImport"/>
         <module name="CustomImportOrder">
             <property name="customImportOrderRules"
                       value="STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SAME_PACKAGE(2)###STATIC"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -67,12 +67,12 @@
         </module>
         <module name="MissingJavadocMethod">
             <property name="minLineCount" value="2"/>
-            <property name="allowedAnnotations" value="Override, Test, Bean, ApiOperation, ExceptionHandler, ApiModelProperty"/>
+            <property name="allowedAnnotations" value="Override, Test, Bean, ApiOperation, ExceptionHandler, ApiModelProperty, Operation"/>
             <property name="allowMissingPropertyJavadoc" value="true"/>
         </module>
         <module name="JavadocType"/>
         <module name="MissingJavadocType">
-            <property name="skipAnnotations" value="SpringBootApplication, Configuration, Bean, ApiModel"/>
+            <property name="skipAnnotations" value="SpringBootApplication, Configuration, Bean, ApiModel, Schema, Tag"/>
         </module>
         <module name="JavadocVariable">
             <property name="scope" value="public"/>


### PR DESCRIPTION
- Enforce imports order as described in the style guide.
- Ignore javadoc absence for methods and classes annotated with springdoc-openapi, to avoid documentation duplication.
- Prohibit star (wildcard) imports.